### PR TITLE
Use util.inherits for functional prototypes

### DIFF
--- a/lib/spb.js
+++ b/lib/spb.js
@@ -6,8 +6,9 @@
 // 9007199254740992; and in any case, the largest buffer or string one
 // can allocate is usually rather smaller than 4GB.
 
-var stream = require('stream');
-var events = require('events');
+var Stream = require('stream').Stream;
+var Emitter = require('events').EventEmitter;
+var util = require('util');
 
 // Fun fact: JavaScript bitshifts are only defined on signed 32-bit
 // integers, so lshifting anything greater than 128 by 24 will give a
@@ -21,10 +22,10 @@ function readsize(buffer0, offset) {
         (buffer[2] << 8) +
         buffer[3];
 }
-module.exports.readsize = readsize;
+exports.readsize = readsize;
 
 function BlobStream(underlying) {
-    stream.Stream.call(this);
+    Stream.call(this);
 
     this._underlying = underlying;
     this._encoding = null;
@@ -172,8 +173,9 @@ function BlobStream(underlying) {
     this.writable = underlying.writable;
 }
 
-(function(proto) {
+util.inherits(BlobStream, Stream);
 
+(function(proto) {
     proto.setEncoding = function(encoding) {
         this._encoding = encoding;
     };
@@ -219,12 +221,10 @@ function BlobStream(underlying) {
             // TODO factor out to avoid alloc?
             this.write(new Buffer(data, encoding));
         }
-    }
+    };
+})(BlobStream.prototype);
 
-    BlobStream.prototype = proto;
-})(new stream.Stream());
-
-module.exports.stream = function(underlying) {
+exports.stream = function(underlying) {
     return new BlobStream(underlying);
 };
 
@@ -234,25 +234,23 @@ module.exports.stream = function(underlying) {
 // from the underlying server.
 
 function BlobServer(server) {
-    events.EventEmitter.call(this);
+    Emitter.call(this);
 
     this._underlying = server;
     var that = this;
     server.on('connection', function(stream) {
         that.emit('connection', new BlobStream(stream));
     });
-    server.on('close', function() { that.emit('close'); });
-    server.on('listening', function() { that.emit('listening'); });
+    server.on('close', this.emit.bind(this, 'close'));
+    server.on('listening', this.emit.bind(this, 'listening'));
 }
 
-(function(proto) {
-    proto.close = function() {
-        return this._underlying.close();
-    }
+util.inherits(BlobServer, Emitter);
 
-    BlobServer.prototype = proto;
-})(new events.EventEmitter());
+BlobServer.prototype.close = function() {
+    return this._underlying.close();
+};
 
-module.exports.server = function(underlying) {
+exports.server = function(underlying) {
     return new BlobServer(underlying);
 };


### PR DESCRIPTION
This solves #1, it looks like writing to the stream wasn't working because it "inherited" from the same instance of Stream. I added `util.inherits` and corrected prototyping, so that works now.
